### PR TITLE
Fix DomainStack aws resource creation scope (#43)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.wcdevs.blog</groupId>
   <artifactId>cdk</artifactId>
-  <version>1.1.1</version>
+  <version>1.1.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>wcDevs.org AWS CDK Constructs</name>
@@ -53,7 +53,7 @@
     <developerConnection>scm:git:https://github.com/lealceldeiro/org.wcdevs.blog.cdk.git
     </developerConnection>
     <url>https://github.com/lealceldeiro/org.wcdevs.blog.cdk</url>
-    <tag>cdk-1.1.1</tag>
+    <tag>org.wcdevs.blog.cdk-${project.version}</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.wcdevs.blog</groupId>
   <artifactId>cdk</artifactId>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.1.1</version>
   <packaging>jar</packaging>
 
   <name>wcDevs.org AWS CDK Constructs</name>
@@ -53,7 +53,7 @@
     <developerConnection>scm:git:https://github.com/lealceldeiro/org.wcdevs.blog.cdk.git
     </developerConnection>
     <url>https://github.com/lealceldeiro/org.wcdevs.blog.cdk</url>
-    <tag>org.wcdevs.blog.cdk-${project.version}</tag>
+    <tag>cdk-1.1.1</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
- Use domainStack constructed object as scope for internally created resources