### PR TITLE
Enhancement: Handle https listener creation in Network construct (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,21 @@
 Holds CDK constructs with an opinionated AWS CDK configured resources which provides capabilities
 to define AWS cloud resources. Many of the configuration can be modified via input arguments.
 
-Users of this library, depending also on the AWS CDK itself must use version `1.130.0` of the
+Users of this library, depending also on the AWS CDK itself must use version `1.131.0` of the
 [AWS CDK](https://mvnrepository.com/artifact/software.amazon.awscdk). 
 
 This is a [Maven](https://maven.apache.org/) based project, so you can open it with any Maven
 compatible Java IDE to build and run tests.
+
+To add it as a dependency from Maven Central to your project, add it to your `pom.xml` like this:
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>org.wcdevs.blog</groupId>
+    <artifactId>cdk</artifactId>
+    <version>1.2.0</version>
+  </dependency>
+</dependencies>
+```
+For more options, see https://mvnrepository.com/artifact/org.wcdevs.blog/cdk

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.wcdevs.blog</groupId>
   <artifactId>cdk</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>wcDevs.org AWS CDK Constructs</name>
@@ -53,7 +53,7 @@
     <developerConnection>scm:git:https://github.com/lealceldeiro/org.wcdevs.blog.cdk.git
     </developerConnection>
     <url>https://github.com/lealceldeiro/org.wcdevs.blog.cdk</url>
-    <tag>cdk-1.2.0</tag>
+    <tag>org.wcdevs.blog.cdk-${project.version}</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.wcdevs.blog</groupId>
   <artifactId>cdk</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.0</version>
   <packaging>jar</packaging>
 
   <name>wcDevs.org AWS CDK Constructs</name>
@@ -53,7 +53,7 @@
     <developerConnection>scm:git:https://github.com/lealceldeiro/org.wcdevs.blog.cdk.git
     </developerConnection>
     <url>https://github.com/lealceldeiro/org.wcdevs.blog.cdk</url>
-    <tag>org.wcdevs.blog.cdk-${project.version}</tag>
+    <tag>cdk-1.2.0</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.wcdevs.blog</groupId>
   <artifactId>cdk</artifactId>
-  <version>1.1.6-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>wcDevs.org AWS CDK Constructs</name>
@@ -18,7 +18,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <lombok.version>1.18.22</lombok.version>
-    <cdk.version>1.130.0</cdk.version>
+    <cdk.version>1.131.0</cdk.version>
     <junit.version>5.8.1</junit.version>
     <mockito.version>4.0.0</mockito.version>
   </properties>

--- a/src/test/java/org/wcdevs/blog/cdk/DomainStackTest.java
+++ b/src/test/java/org/wcdevs/blog/cdk/DomainStackTest.java
@@ -1,48 +1,28 @@
 package org.wcdevs.blog.cdk;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.awscdk.core.Construct;
 import software.amazon.awscdk.core.Environment;
 import software.amazon.awscdk.services.elasticloadbalancingv2.ApplicationListener;
 import software.amazon.awscdk.services.elasticloadbalancingv2.ApplicationLoadBalancer;
 
-import java.security.SecureRandom;
-import java.util.Random;
 import java.util.UUID;
-import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 class DomainStackTest {
-  private static final Random RANDOM = new SecureRandom();
-
   private static String randomString() {
     return UUID.randomUUID().toString();
   }
 
-  private static Stream<Arguments> newInstanceArgs() {
-    return Stream.of(arguments(false, false, false),
-                     arguments(true, false, false),
-                     arguments(false, false, true),
-                     arguments(false, true, true),
-                     arguments(true, false, true),
-                     arguments(true, true, false),
-                     arguments(true, true, true));
-  }
-
   @ParameterizedTest
-  @MethodSource("newInstanceArgs")
-  void newInstance(boolean withCustomInputParams, boolean sslActivated,
-                   boolean isThereHttpListenerAlreadyInNetwork) {
+  @ValueSource(booleans = {true, false})
+  void newInstance(boolean sslCertificateExists) {
     StaticallyMockedCdk.executeTest(() -> {
       try (
           var mockedNetwork = mockStatic(Network.class);
@@ -56,8 +36,7 @@ class DomainStackTest {
         when(netOutParamsMock.getLoadBalancerDnsName()).thenReturn(randomString());
         mockedNetwork.when(() -> Network.outputParametersFrom(any(), any()))
                      .thenReturn(netOutParamsMock);
-        mockedNetwork.when(() -> Network.arnNotNull(any()))
-                     .thenReturn(isThereHttpListenerAlreadyInNetwork);
+        mockedNetwork.when(() -> Network.isArnNotNull(any())).thenReturn(sslCertificateExists);
 
         mockedApplicationListener.when(() -> ApplicationListener.fromLookup(any(), any(), any()))
                                  .thenReturn(mock(ApplicationListener.class));
@@ -77,36 +56,9 @@ class DomainStackTest {
         var hostedZoneDomain = randomString();
         var applicationDomain = randomString();
 
-        var inputParams = DomainStack.InputParameters.builder()
-                                                     .httpPortNumber(RANDOM.nextInt())
-                                                     .sslCertificateActivated(sslActivated)
-                                                     .httpPortNumber(RANDOM.nextInt())
-                                                     .build();
-
-        var actual = withCustomInputParams
-                     ? DomainStack.newInstance(scope, id, awsEnv, appEnv, hostedZoneDomain,
-                                               applicationDomain, inputParams)
-                     : DomainStack.newInstance(scope, id, awsEnv, appEnv, hostedZoneDomain,
-                                               applicationDomain);
-        assertNotNull(actual);
+        assertNotNull(DomainStack.newInstance(scope, id, awsEnv, appEnv, hostedZoneDomain,
+                                              applicationDomain));
       }
     });
-  }
-
-  @Test
-  void inputParameters() {
-    var httpsPortNumber = RANDOM.nextInt();
-    var sslCertificateActivated = RANDOM.nextBoolean();
-    var httpPortNumber = RANDOM.nextInt();
-    var parameters = DomainStack.InputParameters.builder()
-                                                .httpsPortNumber(httpsPortNumber)
-                                                .sslCertificateActivated(sslCertificateActivated)
-                                                .httpPortNumber(httpPortNumber)
-                                                .build();
-    assertNotNull(parameters);
-    assertEquals(httpPortNumber, parameters.getHttpPortNumber());
-    assertEquals(httpsPortNumber, parameters.getHttpsPortNumber());
-    assertEquals(String.valueOf(httpsPortNumber), parameters.getHttpsPort());
-    assertEquals(sslCertificateActivated, parameters.isSslCertificateActivated());
   }
 }

--- a/src/test/java/org/wcdevs/blog/cdk/NetworkTest.java
+++ b/src/test/java/org/wcdevs/blog/cdk/NetworkTest.java
@@ -289,6 +289,7 @@ class NetworkTest {
       assertEquals(expected, output.getHttpListenerArn());
       assertEquals(expected, output.getHttpsListenerArn().orElseThrow());
       assertEquals(expected, output.getLoadbalancerSecurityGroupId());
+      assertEquals(expected, output.getSslCertificateArn());
       assertEquals(expected, output.getEcsClusterName());
       assertEquals(expected, output.getLoadBalancerArn());
       assertEquals(expected, output.getLoadBalancerDnsName());
@@ -348,14 +349,16 @@ class NetworkTest {
     var maxAZs = random.nextInt();
     var listeningExternalPort = random.nextInt();
     var listeningInternalPort = random.nextInt();
+    var listeningHttpsPort = random.nextInt();
     var input = Network.InputParameters.builder()
                                        .sslCertificateArn(sslCertificateArn)
                                        .natGatewayNumber(natGatewayNumber)
                                        .numberOfIsolatedSubnetsPerAZ(numberOfIsolatedSubnetsPerAZ)
                                        .numberOfPublicSubnetsPerAZ(numberOfPublicSubnetsPerAZ)
                                        .maxAZs(maxAZs)
-                                       .listeningExternalPort(listeningExternalPort)
-                                       .listeningInternalPort(listeningInternalPort)
+                                       .listeningExternalHttpPort(listeningExternalPort)
+                                       .listeningInternalHttpPort(listeningInternalPort)
+                                       .listeningHttpsPort(listeningHttpsPort)
                                        .build();
 
     assertNotNull(input);
@@ -364,7 +367,20 @@ class NetworkTest {
     assertEquals(numberOfIsolatedSubnetsPerAZ, input.getNumberOfIsolatedSubnetsPerAZ());
     assertEquals(numberOfPublicSubnetsPerAZ, input.getNumberOfPublicSubnetsPerAZ());
     assertEquals(maxAZs, input.getMaxAZs());
-    assertEquals(listeningExternalPort, input.getListeningExternalPort());
-    assertEquals(listeningInternalPort, input.getListeningInternalPort());
+    assertEquals(listeningExternalPort, input.getListeningExternalHttpPort());
+    assertEquals(listeningInternalPort, input.getListeningInternalHttpPort());
+    assertEquals(listeningHttpsPort, input.getListeningHttpsPort());
+    assertEquals(String.valueOf(listeningHttpsPort), input.getListeningHttpsPortString());
+  }
+
+  private static Stream<Arguments> isArnNotNullReturnsCorrectlyArgs() {
+    return Stream.of(arguments(randomString(), true), arguments("", false), arguments("  ", false),
+                     arguments(null, false), arguments("null", false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("isArnNotNullReturnsCorrectlyArgs")
+  void isArnNotNullReturnsCorrectly(String input, boolean expected) {
+    assertEquals(expected, Network.isArnNotNull(input));
   }
 }


### PR DESCRIPTION
* Update DomainStack and Network constructs
- Move https listener creation to network construct
- Do check for ssl (activated or not) using the certificate arn stored (and retrieved) using the network construct

* Update pom.xml
- Bump version to 1.2.0
- Bump aws cdk version to 1.131.0

* Update README.md
- Update aws cdk version to use along with this library
- Add how to add it to a project dependency